### PR TITLE
Use Swift Testing for Test Suites

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,13 +18,19 @@ let package = Package(
       targets: ["Vectors"]
     ),
   ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-numerics", from: "1.0.2")
+  ],
   targets: [
     .target(
       name: "Vectors"
     ),
     .testTarget(
       name: "VectorsTests",
-      dependencies: ["Vectors"]
+      dependencies: [
+        "Vectors",
+        .product(name: "Numerics", package: "swift-numerics"),
+      ]
     ),
   ]
 )

--- a/Tests/VectorsTests/VectorPolarCoordinatesTests.swift
+++ b/Tests/VectorsTests/VectorPolarCoordinatesTests.swift
@@ -1,34 +1,44 @@
-import XCTest
+import Foundation
+import Numerics
+import Testing
 @testable import Vectors
 
-final class VectorPolarCoordinatesTests: XCTestCase {
-  func testUnitVectorInPolarPlane() {
+@Suite("Vector Polar Coordinates Test") struct VectorPolarCoordinatesTests {
+  @Test func testUnitVectorInPolarPlane() {
     let vector = CGPoint(angle: .degrees(90), radius: 1)
 
-    XCTAssertEqual(vector.x, 0, accuracy: 0.0001)
-    XCTAssertEqual(vector.y, 1, accuracy: 0.0001)
+    #expect(vector.x.isApproximatelyEqual(to: 0, absoluteTolerance: 0.0001))
+    #expect(vector.y.isApproximatelyEqual(to: 1, absoluteTolerance: 0.0001))
   }
 
-  func testVectorInPolarPlane() {
+  @Test func testVectorInPolarPlane() {
     let vector = CGPoint(angle: .degrees(180), radius: 20)
 
-    XCTAssertEqual(vector.x, -20, accuracy: 0.0001)
-    XCTAssertEqual(vector.y, 0, accuracy: 0.0001)
+    #expect(vector.x.isApproximatelyEqual(to: -20, absoluteTolerance: 0.0001))
+    #expect(vector.y.isApproximatelyEqual(to: 0, absoluteTolerance: 0.0001))
   }
 
-  func testVectorInRectangle() {
+  @Test func testVectorInRectangle() {
     let rect = CGRect(x: 0, y: 0, width: 400, height: 400)
-    let vector = CGPoint(angle: .degrees(90), in: rect)
+    let vector = CGPoint(
+      angle: .degrees(90),
+      radius: rect.width / 2,
+      center: CGPoint(x: rect.midX, y: rect.midY)
+    )
 
-    XCTAssertEqual(vector.x, 200, accuracy: 0.0001)
-    XCTAssertEqual(vector.y, 400, accuracy: 0.0001)
+    #expect(vector.x.isApproximatelyEqual(to: 200, absoluteTolerance: 0.0001))
+    #expect(vector.y.isApproximatelyEqual(to: 400, absoluteTolerance: 0.0001))
   }
 
-  func testVectorInOffsetRectangle() {
+  @Test func testVectorInOffsetRectangle() {
     let rect = CGRect(x: 100, y: 100, width: 200, height: 200)
-    let vector = CGPoint(angle: .degrees(90), in: rect)
+    let vector = CGPoint(
+      angle: .degrees(90),
+      radius: rect.width / 2,
+      center: CGPoint(x: rect.midX, y: rect.midY)
+    )
 
-    XCTAssertEqual(vector.x, 200, accuracy: 0.0001)
-    XCTAssertEqual(vector.y, 300, accuracy: 0.0001)
+    #expect(vector.x.isApproximatelyEqual(to: 200, absoluteTolerance: 0.0001))
+    #expect(vector.y.isApproximatelyEqual(to: 300, absoluteTolerance: 0.0001))
   }
 }

--- a/Tests/VectorsTests/VectorsTests.swift
+++ b/Tests/VectorsTests/VectorsTests.swift
@@ -1,70 +1,71 @@
-import XCTest
+import Foundation
+import Testing
 @testable import Vectors
 
-final class VectorsTests: XCTestCase {
-  func testSum() {
+@Suite("Vector Operations Tests") struct VectorOperationsTests {
+  @Test func testSum() {
     let a = CGPoint(x: 1, y: 2)
     let b = CGPoint(x: 3, y: 4)
-    XCTAssertEqual(a + b, CGPoint(x: 4, y: 6))
+    #expect(a + b == CGPoint(x: 4, y: 6))
   }
 
-  func testSubtraction() {
-    let a = CGPoint(x: 1, y: 2)
-    let b = CGPoint(x: 3, y: 4)
-
-    XCTAssertEqual(b - a, CGPoint(x: 2, y: 2))
-  }
-
-  func testDirectionOfSubtraction() {
+  @Test func testSubtraction() {
     let a = CGPoint(x: 1, y: 2)
     let b = CGPoint(x: 3, y: 4)
 
-    XCTAssertEqual((b - a).heading, .degrees(45))
-    XCTAssertEqual((a - b).heading, .degrees(-135))
+    #expect(b - a == CGPoint(x: 2, y: 2))
   }
 
-  func testScalarMultiplication() {
+  @Test func testDirectionOfSubtraction() {
+    let a = CGPoint(x: 1, y: 2)
+    let b = CGPoint(x: 3, y: 4)
+
+    #expect((b - a).heading == .degrees(45))
+    #expect((a - b).heading == .degrees(-135))
+  }
+
+  @Test func testScalarMultiplication() {
     let a = CGPoint(x: 1, y: 2)
 
-    XCTAssertEqual(a * 2, CGPoint(x: 2, y: 4))
+    #expect(a * 2 == CGPoint(x: 2, y: 4))
   }
 
-  func testScalarDivision() {
+  @Test func testScalarDivision() {
     let a = CGPoint(x: 4, y: 6)
 
-    XCTAssertEqual(a / 2, CGPoint(x: 2, y: 3))
+    #expect(a / 2 == CGPoint(x: 2, y: 3))
   }
 
-  func testMagnitude() {
+  @Test func testMagnitude() {
     let a = CGPoint(x: 3, y: 4)
     let b = CGPoint(x: 0, y: 0)
 
-    XCTAssertEqual(a.magnitude, 5)
-    XCTAssertEqual(b.magnitude, 0)
+    #expect(a.magnitude == 5)
+    #expect(b.magnitude == 0)
   }
 
-  func testHeading() {
+  @Test func testHeading() {
     let a = CGPoint(x: 4, y: -4)
 
-    XCTAssertEqual(a.heading.degrees, -45)
+    #expect(a.heading.degrees == -45)
   }
 
-  func testNormalization() {
+  @Test func testNormalization() {
     let a = CGPoint(x: 3, y: 4)
     let b = CGPoint(x: 0.5, y: 0.5)
     let c = CGPoint(x: 0, y: 0)
 
-    XCTAssertEqual(a.normalized.magnitude, 1, accuracy: 0.001)
-    XCTAssertEqual(b.normalized.magnitude, 1, accuracy: 0.001)
+    #expect(a.normalized.magnitude.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
+    #expect(b.normalized.magnitude.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
 
-    XCTAssertEqual(c.normalized, CGPoint(x: 0, y: 0))
+    #expect(c.normalized == CGPoint(x: 0, y: 0))
   }
 
-  func testLimit() {
+  @Test func testLimit() {
     let a = CGPoint(x: 6, y: 8)
     let b = CGPoint(x: 3, y: 4)
 
-    XCTAssertEqual(a.limit(5), CGPoint(x: 3, y: 4))
-    XCTAssertEqual(b.limit(6), CGPoint(x: 3, y: 4))
+    #expect(a.limit(5) == CGPoint(x: 3, y: 4))
+    #expect(b.limit(6) == CGPoint(x: 3, y: 4))
   }
 }


### PR DESCRIPTION
This PR migrates test suites from `XCTest` to `Swift Testing`.