### PR TITLE
Add Mutable Operations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "bb8483ae00d196c2e4006a55ffb6136287789602ae01d9c631a264b511ace5e4",
+  "pins" : [
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/Vectors/Vector.swift
+++ b/Sources/Vectors/Vector.swift
@@ -92,6 +92,22 @@ public extension Vector {
   static func /(vector: Self, scalar: CGFloat) -> Self {
     vector.divided(by: scalar)
   }
+  
+  static func +=(lhs: inout Self, rhs: some Vector) {
+    lhs = lhs + rhs
+  }
+  
+  static func -=(lhs: inout Self, rhs: some Vector) {
+    lhs = lhs - rhs
+  }
+  
+  static func *=(lhs: inout Self, rhs: CGFloat) {
+    lhs = lhs * rhs
+  }
+  
+  static func /=(lhs: inout Self, rhs: CGFloat) {
+    lhs = lhs / rhs
+  }
 }
 
 // MARK: - Helpers
@@ -112,6 +128,11 @@ public extension Vector {
   var magnitude: CGFloat {
     sqrt(x * x + y * y)
   }
+  
+  /// Returns the length (or magnitude) of the vector.
+  var length: CGFloat {
+    magnitude
+  }
 
   /// The heading (direction) of the vector expressed as an angle.
   /// - Returns: An `Angle` in the range `[-π, π]`.
@@ -130,5 +151,8 @@ public extension Vector {
 
     return normalized * maximum
   }
+  
+  mutating func normalize() {
+    self = normalized
+  }
 }
-

--- a/Sources/Vectors/Vector.swift
+++ b/Sources/Vectors/Vector.swift
@@ -144,12 +144,16 @@ public extension Vector {
   /// Scales the vector to avoid exceeding the passed maximum magnitude.
   /// - Parameter maximum: The maximum magnitude of the vector.
   /// - Returns: The scaled vector, if it exceeds the passed magnitude.
-  func limit(_ maximum: CGFloat) -> Self {
-    guard magnitude > maximum else {
+  mutating func limit(to length: CGFloat) {
+    self = limited(to: length)
+  }
+  
+  func limited(to length: CGFloat) -> Self {
+    guard magnitude > length else {
       return self
     }
 
-    return normalized * maximum
+    return normalized * length
   }
   
   mutating func normalize() {

--- a/Sources/Vectors/Vector.swift
+++ b/Sources/Vectors/Vector.swift
@@ -115,13 +115,9 @@ public extension Vector {
 public extension Vector {
   /// Returns a vector normalized to a unit length of 1.
   var normalized: Self {
-    let magnitude = self.magnitude
-
-    guard magnitude > .zero else {
-      return self
-    }
-
-    return self / magnitude
+    var vector = self
+    vector.normalize()
+    return vector
   }
 
   /// Returns the magnitude (or length) of the vector.
@@ -134,29 +130,38 @@ public extension Vector {
     magnitude
   }
 
-  /// The heading (direction) of the vector expressed as an angle.
+  /// The heading (i.e.: direction) of the vector expressed as an angle.
   /// - Returns: An `Angle` in the range `[-π, π]`.
   var heading: Angle {
     let angle = atan2(y, x)
     return Angle(radians: angle)
   }
 
-  /// Scales the vector to avoid exceeding the passed maximum magnitude.
-  /// - Parameter maximum: The maximum magnitude of the vector.
-  /// - Returns: The scaled vector, if it exceeds the passed magnitude.
-  mutating func limit(to length: CGFloat) {
-    self = limited(to: length)
-  }
-  
   func limited(to length: CGFloat) -> Self {
+    var vector = self
+    vector.limit(to: length)
+    return vector
+  }
+
+  /// Scales the vector to avoid exceeding the specified length.
+  /// - Parameter length: The maximum length of the vector.
+  /// - Returns: The scaled vector, if it exceeds the specified length.
+  mutating func limit(to length: CGFloat) {
     guard magnitude > length else {
-      return self
+      return
     }
 
-    return normalized * length
+    normalize()
+    self *= length
   }
-  
+
   mutating func normalize() {
-    self = normalized
+    let magnitude = self.magnitude
+
+    guard magnitude > .zero else {
+      return
+    }
+
+    self /= magnitude
   }
 }

--- a/Sources/Vectors/Vector.swift
+++ b/Sources/Vectors/Vector.swift
@@ -113,7 +113,7 @@ public extension Vector {
 // MARK: - Helpers
 
 public extension Vector {
-  /// Returns a vector normalized to a unit length of 1.
+  /// Returns a vector normalized to a unit length of `1`.
   var normalized: Self {
     var vector = self
     vector.normalize()
@@ -137,6 +137,9 @@ public extension Vector {
     return Angle(radians: angle)
   }
 
+  /// Returns the vector scaled to avoid exceeding the specified length.
+  /// - Parameter length: The maximum length of the vector.
+  /// - Returns: The scaled vector, if it exceeds the specified length.
   func limited(to length: CGFloat) -> Self {
     var vector = self
     vector.limit(to: length)
@@ -155,6 +158,7 @@ public extension Vector {
     self *= length
   }
 
+  /// Normalizes the vector to a length of `1`.
   mutating func normalize() {
     let magnitude = self.magnitude
 

--- a/Tests/VectorsTests/VectorPolarCoordinatesTests.swift
+++ b/Tests/VectorsTests/VectorPolarCoordinatesTests.swift
@@ -4,21 +4,21 @@ import Testing
 @testable import Vectors
 
 @Suite("Vector Polar Coordinates Test") struct VectorPolarCoordinatesTests {
-  @Test func testUnitVectorInPolarPlane() {
+  @Test func convertUnitVectorToPolarPlane() {
     let vector = CGPoint(angle: .degrees(90), radius: 1)
 
     #expect(vector.x.isApproximatelyEqual(to: 0, absoluteTolerance: 0.0001))
     #expect(vector.y.isApproximatelyEqual(to: 1, absoluteTolerance: 0.0001))
   }
 
-  @Test func testVectorInPolarPlane() {
+  @Test func convertVectorToPolarPlane() {
     let vector = CGPoint(angle: .degrees(180), radius: 20)
 
     #expect(vector.x.isApproximatelyEqual(to: -20, absoluteTolerance: 0.0001))
     #expect(vector.y.isApproximatelyEqual(to: 0, absoluteTolerance: 0.0001))
   }
 
-  @Test func testVectorInRectangle() {
+  @Test func vectorInRectangle() {
     let rect = CGRect(x: 0, y: 0, width: 400, height: 400)
     let vector = CGPoint(
       angle: .degrees(90),
@@ -30,7 +30,7 @@ import Testing
     #expect(vector.y.isApproximatelyEqual(to: 400, absoluteTolerance: 0.0001))
   }
 
-  @Test func testVectorInOffsetRectangle() {
+  @Test func vectorInOffsetRectangle() {
     let rect = CGRect(x: 100, y: 100, width: 200, height: 200)
     let vector = CGPoint(
       angle: .degrees(90),

--- a/Tests/VectorsTests/VectorsTests.swift
+++ b/Tests/VectorsTests/VectorsTests.swift
@@ -121,8 +121,23 @@ import Testing
     let b = CGPoint(x: 3, y: 4)
     let c = CGPoint(x: 2, y: 1)
 
-    #expect(a.limit(5) == CGPoint(x: 3, y: 4), "The components of the vector should change if its length exceeds the specified limit.")
-    #expect(b.limit(6) == CGPoint(x: 3, y: 4), "The components of the vector should change only if its length exceeds the specified limit.")
-    #expect(c.limit(6) == CGPoint(x: 2, y: 1), "The components of the vector should change only if its length exceeds the specified limit.")
+    #expect(a.limited(to: 5) == CGPoint(x: 3, y: 4), "The components of the vector should change if its length exceeds the specified limit.")
+    #expect(b.limited(to: 6) == CGPoint(x: 3, y: 4), "The components of the vector should change only if its length exceeds the specified limit.")
+    #expect(c.limited(to: 6) == CGPoint(x: 2, y: 1), "The components of the vector should change only if its length exceeds the specified limit.")
+  }
+  
+  @Test func mutableLimit() {
+    var a = CGPoint(x: 6, y: 8)
+    a.limit(to: 5)
+    
+    var b = CGPoint(x: 3, y: 4)
+    b.limit(to: 6)
+    
+    var c = CGPoint(x: 2, y: 1)
+    c.limit(to: 6)
+
+    #expect(a == CGPoint(x: 3, y: 4), "The components of the vector should change if its length exceeds the specified limit.")
+    #expect(b == CGPoint(x: 3, y: 4), "The components of the vector should change only if its length exceeds the specified limit.")
+    #expect(c == CGPoint(x: 2, y: 1), "The components of the vector should change only if its length exceeds the specified limit.")
   }
 }

--- a/Tests/VectorsTests/VectorsTests.swift
+++ b/Tests/VectorsTests/VectorsTests.swift
@@ -3,20 +3,38 @@ import Testing
 @testable import Vectors
 
 @Suite("Vector Operations Tests") struct VectorOperationsTests {
-  @Test func testSum() {
+  @Test func sum() {
     let a = CGPoint(x: 1, y: 2)
     let b = CGPoint(x: 3, y: 4)
     #expect(a + b == CGPoint(x: 4, y: 6))
   }
+  
+  @Test func mutableSum() {
+    var a = CGPoint(x: 1, y: 2)
+    let b = CGPoint(x: 3, y: 4)
+    
+    a += b
+    
+    #expect(a == CGPoint(x: 4, y: 6))
+  }
 
-  @Test func testSubtraction() {
+  @Test func subtraction() {
     let a = CGPoint(x: 1, y: 2)
     let b = CGPoint(x: 3, y: 4)
 
     #expect(b - a == CGPoint(x: 2, y: 2))
   }
 
-  @Test func testDirectionOfSubtraction() {
+  @Test func mutableSubtraction() {
+    let a = CGPoint(x: 1, y: 2)
+    var b = CGPoint(x: 3, y: 4)
+
+    b -= a
+    
+    #expect(b == CGPoint(x: 2, y: 2))
+  }
+  
+  @Test func subtractionHeading() {
     let a = CGPoint(x: 1, y: 2)
     let b = CGPoint(x: 3, y: 4)
 
@@ -24,19 +42,35 @@ import Testing
     #expect((a - b).heading == .degrees(-135))
   }
 
-  @Test func testScalarMultiplication() {
+  @Test func scalarMultiplication() {
     let a = CGPoint(x: 1, y: 2)
 
     #expect(a * 2 == CGPoint(x: 2, y: 4))
   }
+  
+  @Test func mutableScalarMultiplication() {
+    var a = CGPoint(x: 1, y: 2)
+    
+    a *= 2
 
-  @Test func testScalarDivision() {
+    #expect(a == CGPoint(x: 2, y: 4))
+  }
+
+  @Test func scalarDivision() {
     let a = CGPoint(x: 4, y: 6)
 
     #expect(a / 2 == CGPoint(x: 2, y: 3))
   }
 
-  @Test func testMagnitude() {
+  @Test func mutableScalarDivision() {
+    var a = CGPoint(x: 4, y: 6)
+
+    a /= 2
+    
+    #expect(a == CGPoint(x: 2, y: 3))
+  }
+
+  @Test func magnitude() {
     let a = CGPoint(x: 3, y: 4)
     let b = CGPoint(x: 0, y: 0)
 
@@ -44,28 +78,51 @@ import Testing
     #expect(b.magnitude == 0)
   }
 
-  @Test func testHeading() {
+  @Test func heading() {
     let a = CGPoint(x: 4, y: -4)
 
     #expect(a.heading.degrees == -45)
   }
 
-  @Test func testNormalization() {
+  @Test(
+    arguments: [
+      CGPoint(x: 3, y: 4),
+      CGPoint(x: 0.5, y: 0.5)
+    ]
+  )
+  func normalization(vector: Vector) {
     let a = CGPoint(x: 3, y: 4)
     let b = CGPoint(x: 0.5, y: 0.5)
-    let c = CGPoint(x: 0, y: 0)
 
-    #expect(a.normalized.magnitude.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
-    #expect(b.normalized.magnitude.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
+    #expect(a.normalized.length.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
+    #expect(b.normalized.length.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
+  }
+  
+  @Test func zeroVectorNormalization() {
+    let zero = CGPoint.zero
+    #expect(zero.normalized.length == .zero, "The length of a zero vector should always be zero.")
+  }
+  
+  @Test(
+    arguments: [
+      CGPoint(x: 3, y: 4),
+      CGPoint(x: 0.5, y: 0.5)
+    ]
+  )
+  func mutableNormalization(vector: Vector) {
+    var vector = vector
+    vector.normalize()
 
-    #expect(c.normalized == CGPoint(x: 0, y: 0))
+    #expect(vector.length.isApproximatelyEqual(to: 1, relativeTolerance: 0.001))
   }
 
-  @Test func testLimit() {
+  @Test func limit() {
     let a = CGPoint(x: 6, y: 8)
     let b = CGPoint(x: 3, y: 4)
+    let c = CGPoint(x: 2, y: 1)
 
-    #expect(a.limit(5) == CGPoint(x: 3, y: 4))
-    #expect(b.limit(6) == CGPoint(x: 3, y: 4))
+    #expect(a.limit(5) == CGPoint(x: 3, y: 4), "The components of the vector should change if its length exceeds the specified limit.")
+    #expect(b.limit(6) == CGPoint(x: 3, y: 4), "The components of the vector should change only if its length exceeds the specified limit.")
+    #expect(c.limit(6) == CGPoint(x: 2, y: 1), "The components of the vector should change only if its length exceeds the specified limit.")
   }
 }


### PR DESCRIPTION
These changes allow operations to mutate instances of vectors, rather than creating new copies.

## Changes
- Added addition, subtraction, multiplication, and division assignment operators.
- Added `normalize()` function to normalize a variable vector instance in place.
- Added a new `length` property to get the length of a vector. This is the same as `magnitude`.
- Renamed the immutable `limit(to:)` function to `limited(to:)`. The `limit(to:)` function is now reserved for mutable instances.